### PR TITLE
docs: fix split word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # kylesmod
 
 This software is licensed under the GNU General Public License v3.0.
-Any public redistribution of this work must include a clear statement that the original author is Slyrae, and must not imply sole authorship by anyone else. Forks or modified versions must include a notice of the original source, with a working link to the original repository, and describe the changes made.
+Any public redistribution of this work must include a clear statement that the original author is Slyrae, and must not imply sole authorship by anyone else.
+Forks or modified versions must include a notice of the original source, with a working link to the original repository, and describe the changes made.


### PR DESCRIPTION
## Summary
- fix truncated phrase in README to avoid word splitting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eeebb2d948323a9861a9bf8c4d474